### PR TITLE
Fix architecture specific versions mirroring in spack mirror --all (#51363)

### DIFF
--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -599,46 +599,49 @@ def process_mirror_stats(present, mirrored, error):
 
 def mirror_create(args):
     """create a directory to be used as a spack mirror, and fill it with package archives"""
-    if args.file and args.all:
-        raise SpackError(
-            "cannot specify specs with a file if you chose to mirror all specs with '--all'"
-        )
-
-    if args.file and args.specs:
-        raise SpackError("cannot specify specs with a file AND on command line")
-
-    if not args.specs and not args.file and not args.all:
-        raise SpackError(
-            "no packages were specified.",
-            "To mirror all packages, use the '--all' option "
-            "(this will require significant time and space).",
-        )
-
-    if args.versions_per_spec and args.all:
-        raise SpackError(
-            "cannot specify '--versions_per-spec' and '--all' together",
-            "The option '--all' already implies mirroring all versions for each package.",
-        )
-
-    # When no directory is provided, the source dir is used
-    path = args.directory or spack.caches.fetch_cache_location()
-
-    mirror_specs = _specs_to_mirror(args)
-    workers = args.jobs
-    if workers is None:
-        if args.all:
-            workers = min(
-                16, spack.config.determine_number_of_jobs(parallel=True), len(mirror_specs)
+    spack.mirrors.utils.set_mirror_all(bool(args.all))
+    try:
+        if args.file and args.all:
+            raise SpackError(
+                "cannot specify specs with a file if you chose to mirror all specs with '--all'"
             )
-        else:
-            workers = 1
 
-    create_mirror_for_all_specs(
-        mirror_specs,
-        path=path,
-        skip_unstable_versions=args.skip_unstable_versions,
-        workers=workers,
-    )
+        if args.file and args.specs:
+            raise SpackError("cannot specify specs with a file AND on command line")
+
+        if not args.specs and not args.file and not args.all:
+            raise SpackError(
+                "no packages were specified.",
+                "To mirror all packages, use the '--all' option "
+                "(this will require significant time and space).",
+            )
+
+        if args.versions_per_spec and args.all:
+            raise SpackError(
+                "cannot specify '--versions_per-spec' and '--all' together",
+                "The option '--all' already implies mirroring all versions for each package.",
+            )
+
+        # When no directory is provided, the source dir is used
+        path = args.directory or spack.caches.fetch_cache_location()
+        mirror_specs = _specs_to_mirror(args)
+        workers = args.jobs
+        if workers is None:
+            if args.all:
+                workers = min(
+                    16, spack.config.determine_number_of_jobs(parallel=True), len(mirror_specs)
+                )
+            else:
+                workers = 1
+
+        create_mirror_for_all_specs(
+            mirror_specs,
+            path=path,
+            skip_unstable_versions=args.skip_unstable_versions,
+            workers=workers,
+        )
+    finally:
+        spack.mirrors.utils.set_mirror_all(False)
 
 
 def _specs_to_mirror(args):

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -598,50 +598,54 @@ def process_mirror_stats(present, mirrored, error):
 
 
 def mirror_create(args):
-    """create a directory to be used as a spack mirror, and fill it with package archives"""
     spack.mirrors.utils.set_mirror_all(bool(args.all))
     try:
-        if args.file and args.all:
-            raise SpackError(
-                "cannot specify specs with a file if you chose to mirror all specs with '--all'"
-            )
-
-        if args.file and args.specs:
-            raise SpackError("cannot specify specs with a file AND on command line")
-
-        if not args.specs and not args.file and not args.all:
-            raise SpackError(
-                "no packages were specified.",
-                "To mirror all packages, use the '--all' option "
-                "(this will require significant time and space).",
-            )
-
-        if args.versions_per_spec and args.all:
-            raise SpackError(
-                "cannot specify '--versions_per-spec' and '--all' together",
-                "The option '--all' already implies mirroring all versions for each package.",
-            )
-
-        # When no directory is provided, the source dir is used
-        path = args.directory or spack.caches.fetch_cache_location()
-        mirror_specs = _specs_to_mirror(args)
-        workers = args.jobs
-        if workers is None:
-            if args.all:
-                workers = min(
-                    16, spack.config.determine_number_of_jobs(parallel=True), len(mirror_specs)
-                )
-            else:
-                workers = 1
-
-        create_mirror_for_all_specs(
-            mirror_specs,
-            path=path,
-            skip_unstable_versions=args.skip_unstable_versions,
-            workers=workers,
-        )
+        _mirror_create(args)
     finally:
         spack.mirrors.utils.set_mirror_all(False)
+
+
+def _mirror_create(args):
+    """create a directory to be used as a spack mirror, and fill it with package archives"""
+    if args.file and args.all:
+        raise SpackError(
+            "cannot specify specs with a file if you chose to mirror all specs with '--all'"
+        )
+
+    if args.file and args.specs:
+        raise SpackError("cannot specify specs with a file AND on command line")
+
+    if not args.specs and not args.file and not args.all:
+        raise SpackError(
+            "no packages were specified.",
+            "To mirror all packages, use the '--all' option "
+            "(this will require significant time and space).",
+        )
+
+    if args.versions_per_spec and args.all:
+        raise SpackError(
+            "cannot specify '--versions_per-spec' and '--all' together",
+            "The option '--all' already implies mirroring all versions for each package.",
+        )
+
+    # When no directory is provided, the source dir is used
+    path = args.directory or spack.caches.fetch_cache_location()
+    mirror_specs = _specs_to_mirror(args)
+    workers = args.jobs
+    if workers is None:
+        if args.all:
+            workers = min(
+                16, spack.config.determine_number_of_jobs(parallel=True), len(mirror_specs)
+            )
+        else:
+            workers = 1
+
+    create_mirror_for_all_specs(
+        mirror_specs,
+        path=path,
+        skip_unstable_versions=args.skip_unstable_versions,
+        workers=workers,
+    )
 
 
 def _specs_to_mirror(args):

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -249,6 +249,10 @@ def _execute_version(pkg: Type[spack.package_base.PackageBase], ver: Union[str, 
             f"    version('{ver}', {args})"
         )
 
+    # URL-based versions can define multiple instances of the same version
+    # e.g. (v1.0, x86_64 and v1.0 for aarch64)
+    # This logic uses a version+hash key to keep track of the versions and avoid
+    # key collisions.
     if spack.mirrors.utils.get_mirror_all_mode() and kwargs.get("url"):
         hash_val = next((kwargs[s] for s in spack.util.crypto.hashes if s in kwargs), None)
         if hash_val:

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -249,14 +249,14 @@ def _execute_version(pkg: Type[spack.package_base.PackageBase], ver: Union[str, 
             f"    version('{ver}', {args})"
         )
 
-    # Store kwargs for the package to later with a fetch_strategy.
-    pkg.versions[version] = kwargs #ANGI DEBUG
-
     if spack.mirrors.utils.get_mirror_all_mode() and kwargs.get("url"):
-        hash_val = (next(kwargs[s] for s in spack.util.crypto.hashes if s in kwargs), None)
+        hash_val = next((kwargs[s] for s in spack.util.crypto.hashes if s in kwargs), None)
         if hash_val:
             version_obj = Version(f"{version}.{hash_val[:16]}")
             pkg.versions[version_obj] = kwargs
+    else:
+        # Store kwargs for the package to later with a fetch_strategy.
+        pkg.versions[version] = kwargs
 
 
 def _depends_on(

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -255,7 +255,6 @@ def _execute_version(pkg: Type[spack.package_base.PackageBase], ver: Union[str, 
             version_obj = Version(f"{version}.{hash_val[:16]}")
             pkg.versions[version_obj] = kwargs
     else:
-        # Store kwargs for the package to later with a fetch_strategy.
         pkg.versions[version] = kwargs
 
 

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -41,6 +41,7 @@ import spack.deptypes as dt
 import spack.error
 import spack.fetch_strategy
 import spack.llnl.util.tty.color
+import spack.mirrors.utils
 import spack.package_base
 import spack.patch
 import spack.spec
@@ -250,6 +251,12 @@ def _execute_version(pkg: Type[spack.package_base.PackageBase], ver: Union[str, 
 
     # Store kwargs for the package to later with a fetch_strategy.
     pkg.versions[version] = kwargs #ANGI DEBUG
+
+    if spack.mirrors.utils.get_mirror_all_mode() and kwargs.get("url"):
+        hash_val = (next(kwargs[s] for s in spack.util.crypto.hashes if s in kwargs), None)
+        if hash_val:
+            version_obj = Version(f"{version}.{hash_val[:16]}")
+            pkg.versions[version_obj] = kwargs
 
 
 def _depends_on(

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -249,7 +249,7 @@ def _execute_version(pkg: Type[spack.package_base.PackageBase], ver: Union[str, 
         )
 
     # Store kwargs for the package to later with a fetch_strategy.
-    pkg.versions[version] = kwargs
+    pkg.versions[version] = kwargs #ANGI DEBUG
 
 
 def _depends_on(

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -25,8 +25,8 @@ def get_mirror_all_mode():
 
 
 def set_mirror_all(enable):
-   global _mirror_all_mode
-   _mirror_all_mode = enable
+    global _mirror_all_mode
+    _mirror_all_mode = enable
 
 
 def evaluate_or_true_if_mirror_all(expression):

--- a/lib/spack/spack/mirrors/utils.py
+++ b/lib/spack/spack/mirrors/utils.py
@@ -17,6 +17,24 @@ from spack.error import MirrorError
 from spack.llnl.util.filesystem import mkdirp
 from spack.mirrors.mirror import Mirror, MirrorCollection
 
+_mirror_all_mode = False
+
+
+def get_mirror_all_mode():
+    return _mirror_all_mode
+
+
+def set_mirror_all(enable):
+   global _mirror_all_mode
+   _mirror_all_mode = enable
+
+
+def evaluate_or_true_if_mirror_all(expression):
+    if get_mirror_all_mode():
+        return True
+    else:
+        return bool(expression)
+
 
 def get_all_versions(specs):
     """Given a set of initial specs, return a new set of specs that includes

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -717,7 +717,8 @@ class Stage(AbstractStage):
             mirror.store(self.fetcher, self.mirror_layout.path)
             stats.added(absolute_storage_path)
 
-        self.mirror_layout.make_alias(mirror.root)
+        if not spack.mirrors.utils.get_mirror_all_mode():
+            self.mirror_layout.make_alias(mirror.root)
 
     def expand_archive(self):
         """Changes to the stage directory and attempt to expand the downloaded

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -24,6 +24,7 @@ import spack.paths
 import spack.platforms
 import spack.repo
 import spack.store
+import spack.mirrors.utils
 
 patches = None
 
@@ -116,12 +117,14 @@ class GlobalStateMarshaler:
         self.config = spack.config.CONFIG.ensure_unwrapped()
         self.platform = spack.platforms.host
         self.store = spack.store.STORE
+        self.mirror_all_mode = spack.mirrors.utils.get_mirror_all_mode()
 
     def restore(self):
         spack.config.CONFIG = self.config
         spack.repo.enable_repo(spack.repo.RepoPath.from_config(self.config))
         spack.platforms.host = self.platform
         spack.store.STORE = self.store
+        spack.mirrors.utils.set_mirror_all(self.mirror_all_mode)
 
 
 class TestPatches:

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -2,8 +2,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import importlib
 import os
 import pathlib
+import sys
 
 import pytest
 
@@ -21,6 +23,7 @@ import spack.util.url as url_util
 import spack.version
 from spack.main import SpackCommand, SpackCommandError
 from spack.mirrors.utils import MirrorStatsForAllSpecs, MirrorStatsForOneSpec
+
 
 config = SpackCommand("config")
 mirror = SpackCommand("mirror")
@@ -760,3 +763,22 @@ def test_git_provenance_relative_to_mirror(
 
     spec_head = spack.concretize.concretize_one(f"git-test-commit@main commit={head_commit}")
     assert spec_head.variants["commit"].value == head_commit
+
+
+def test_evaluate_or_true_if_mirror_all(tmp_path: pathlib.Path, mock_packages, mock_fetch):
+    """Test platform aware mirroring"""
+
+    pkg_module_name = "spack_repo.builtin_mock.packages.arch_specific_pkg.package"
+
+    # Test WITHOUT --all
+    print("Test WITHOUT --all")
+    mirror_dir = str(tmp_path / "mirror")
+    spack.cmd.mirror.set_mirror_all(False)
+    mirror("create", "-d", mirror_dir, "arch-specific-pkg")
+
+    # Test WITH --all (simulated)
+    print("Test WITH --all")
+    mirror_dir_all = str(tmp_path / "mirror-all")
+    spack.cmd.mirror.set_mirror_all(True)
+    importlib.reload(sys.modules[pkg_module_name])
+    mirror("create", "-d", mirror_dir_all, "arch-specific-pkg")

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -24,7 +24,6 @@ import spack.version
 from spack.main import SpackCommand, SpackCommandError
 from spack.mirrors.utils import MirrorStatsForAllSpecs, MirrorStatsForOneSpec
 
-
 config = SpackCommand("config")
 mirror = SpackCommand("mirror")
 env = SpackCommand("env")

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -770,23 +770,17 @@ def test_evaluate_or_true_if_mirror_all(tmp_path: pathlib.Path, mock_packages, m
 
     pkg_module_name = "spack_repo.builtin_mock.packages.arch_specific_pkg.package"
 
-    # Test WITHOUT --all
-    print("\nTest WITHOUT --all")
+    # Test WITHOUT --all for only current arch version
     mirror_dir = str(tmp_path / "mirror")
     spack.mirrors.utils.set_mirror_all(False)
-    mirror("create", "-d", mirror_dir, "arch-specific-pkg")
+    with spack.config.override("config:checksum", False):
+        output = mirror("create", "-d", mirror_dir, "arch-specific-pkg")
+    assert "1    added" in output, f"Expected 1 version, got {output}"
 
-    # Test WITH --all (simulated)
-    print("Test WITH --all")
+    # Test WITH --all for all arch versions
     mirror_dir_all = str(tmp_path / "mirror-all")
     spack.mirrors.utils.set_mirror_all(True)
     importlib.reload(sys.modules[pkg_module_name])
-
-    # Debug: check versions
-    pkg_class = sys.modules[pkg_module_name].ArchSpecificPkg
-    print(f"Versions dict: {pkg_class.versions}")
-    for v, data in pkg_class.versions.items():
-        print(f"  {v}: {data}")
-
-
-    mirror("create", "-d", mirror_dir_all, "arch-specific-pkg")
+    with spack.config.override("config:checksum", False):
+        output = mirror("create", "-d", mirror_dir_all, "-n", "all", "arch-specific-pkg")
+    assert "2    added" in output, f"Expected 2 versions, got {output}"

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -771,14 +771,22 @@ def test_evaluate_or_true_if_mirror_all(tmp_path: pathlib.Path, mock_packages, m
     pkg_module_name = "spack_repo.builtin_mock.packages.arch_specific_pkg.package"
 
     # Test WITHOUT --all
-    print("Test WITHOUT --all")
+    print("\nTest WITHOUT --all")
     mirror_dir = str(tmp_path / "mirror")
-    spack.cmd.mirror.set_mirror_all(False)
+    spack.mirrors.utils.set_mirror_all(False)
     mirror("create", "-d", mirror_dir, "arch-specific-pkg")
 
     # Test WITH --all (simulated)
     print("Test WITH --all")
     mirror_dir_all = str(tmp_path / "mirror-all")
-    spack.cmd.mirror.set_mirror_all(True)
+    spack.mirrors.utils.set_mirror_all(True)
     importlib.reload(sys.modules[pkg_module_name])
+
+    # Debug: check versions
+    pkg_class = sys.modules[pkg_module_name].ArchSpecificPkg
+    print(f"Versions dict: {pkg_class.versions}")
+    for v, data in pkg_class.versions.items():
+        print(f"  {v}: {data}")
+
+
     mirror("create", "-d", mirror_dir_all, "arch-specific-pkg")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/arch_specific_pkg/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/arch_specific_pkg/package.py
@@ -11,8 +11,6 @@ from spack.package import *
 
 class ArchSpecificPkg(Package):
     if spack.mirrors.utils.evaluate_or_true_if_mirror_all(platform.machine() == "x86_64"):
-        print("Adding x86_64 version")
         version("1.0", sha256="a" * 64, url="https://example.com/pkg-1.0-x86_64.tar.gz")
     if spack.mirrors.utils.evaluate_or_true_if_mirror_all(platform.machine() == "aarch64"):
-        print("Adding aarch64 version")
         version("1.0", sha256="b" * 64, url="https://example.com/pkg-1.0-aarch64.tar.gz")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/arch_specific_pkg/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/arch_specific_pkg/package.py
@@ -1,12 +1,13 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import sys
+import platform
 
 from spack_repo.builtin_mock.build_systems.generic import Package
+
 import spack.mirrors.utils
 from spack.package import *
-import platform
+
 
 class ArchSpecificPkg(Package):
     if spack.mirrors.utils.evaluate_or_true_if_mirror_all(platform.machine() == "x86_64"):

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/arch_specific_pkg/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/arch_specific_pkg/package.py
@@ -4,14 +4,14 @@
 import sys
 
 from spack_repo.builtin_mock.build_systems.generic import Package
-from spack.cmd.mirror import evaluate_or_true_if_mirror_all
+import spack.mirrors.utils
 from spack.package import *
 import platform
 
 class ArchSpecificPkg(Package):
-    if evaluate_or_true_if_mirror_all(platform.machine() == "x86_64"):
+    if spack.mirrors.utils.evaluate_or_true_if_mirror_all(platform.machine() == "x86_64"):
         print("Adding x86_64 version")
         version("1.0", sha256="a" * 64)
-    if evaluate_or_true_if_mirror_all(platform.machine() == "aarch64"):
+    if spack.mirrors.utils.evaluate_or_true_if_mirror_all(platform.machine() == "aarch64"):
         print("Adding aarch64 version")
         version("1.0", sha256="b" * 64)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/arch_specific_pkg/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/arch_specific_pkg/package.py
@@ -10,7 +10,11 @@ from spack.package import *
 
 
 class ArchSpecificPkg(Package):
-    if spack.mirrors.utils.evaluate_or_true_if_mirror_all(platform.machine() == "x86_64"):
+    if spack.mirrors.utils.evaluate_or_true_if_mirror_all(
+        platform.machine() in ("x86_64", "AMD64")
+    ):
         version("1.0", sha256="a" * 64, url="https://example.com/pkg-1.0-x86_64.tar.gz")
-    if spack.mirrors.utils.evaluate_or_true_if_mirror_all(platform.machine() == "aarch64"):
+    if spack.mirrors.utils.evaluate_or_true_if_mirror_all(
+        platform.machine() in ("aarch64", "arm64")
+    ):
         version("1.0", sha256="b" * 64, url="https://example.com/pkg-1.0-aarch64.tar.gz")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/arch_specific_pkg/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/arch_specific_pkg/package.py
@@ -11,7 +11,7 @@ import platform
 class ArchSpecificPkg(Package):
     if spack.mirrors.utils.evaluate_or_true_if_mirror_all(platform.machine() == "x86_64"):
         print("Adding x86_64 version")
-        version("1.0", sha256="a" * 64)
+        version("1.0", sha256="a" * 64, url="https://example.com/pkg-1.0-x86_64.tar.gz")
     if spack.mirrors.utils.evaluate_or_true_if_mirror_all(platform.machine() == "aarch64"):
         print("Adding aarch64 version")
-        version("1.0", sha256="b" * 64)
+        version("1.0", sha256="b" * 64, url="https://example.com/pkg-1.0-aarch64.tar.gz")

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/arch_specific_pkg/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/arch_specific_pkg/package.py
@@ -1,0 +1,17 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import sys
+
+from spack_repo.builtin_mock.build_systems.generic import Package
+from spack.cmd.mirror import evaluate_or_true_if_mirror_all
+from spack.package import *
+import platform
+
+class ArchSpecificPkg(Package):
+    if evaluate_or_true_if_mirror_all(platform.machine() == "x86_64"):
+        print("Adding x86_64 version")
+        version("1.0", sha256="a" * 64)
+    if evaluate_or_true_if_mirror_all(platform.machine() == "aarch64"):
+        print("Adding aarch64 version")
+        version("1.0", sha256="b" * 64)

--- a/var/spack/test_repos/spack_repo/builtin_mock/packages/arch_specific_pkg/package.py
+++ b/var/spack/test_repos/spack_repo/builtin_mock/packages/arch_specific_pkg/package.py
@@ -10,11 +10,6 @@ from spack.package import *
 
 
 class ArchSpecificPkg(Package):
-    if spack.mirrors.utils.evaluate_or_true_if_mirror_all(
-        platform.machine() in ("x86_64", "AMD64")
-    ):
-        version("1.0", sha256="a" * 64, url="https://example.com/pkg-1.0-x86_64.tar.gz")
-    if spack.mirrors.utils.evaluate_or_true_if_mirror_all(
-        platform.machine() in ("aarch64", "arm64")
-    ):
-        version("1.0", sha256="b" * 64, url="https://example.com/pkg-1.0-aarch64.tar.gz")
+    version("1.0", sha256="a" * 64, url="https://example.com/pkg-1.0-a.tar.gz")
+    if spack.mirrors.utils.evaluate_or_true_if_mirror_all(False):
+        version("1.0", sha256="b" * 64, url="https://example.com/pkg-1.0-b.tar.gz")


### PR DESCRIPTION
Fixes #51363

When running `spack mirror --all`, packages with architecture specific versions only pull the source for the current host architecture. This causes mirrors to have the wrong source tarball for other architectures.

* Solution
  - Add functionality to determine when `spack mirror --all` is run
  - Store architecture specific versions using key `version.hash` to uniquely identify each tarball
  - Disable symlink aliases in `--all` mode to avoid filename collisions

* Testing
  - Test package with multiple architectures with the same version
  - Test which verifies that both architecture versions are mirrored